### PR TITLE
attachInterruptWakeup() add parameter to define LowPowerMode

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -21,6 +21,11 @@ shutdown	KEYWORD2
 attachInterruptWakeup	KEYWORD2
 enableWakeupFrom	KEYWORD2
 
+IDLE_MODE	LITERAL1
+SLEEP_MODE	LITERAL1
+DEEP_SLEEP_MODE	LITERAL1
+SHUTDOWN_MODE	LITERAL1
+
 #######################################
 # Constants (LITERAL1)
 #######################################

--- a/src/STM32LowPower.cpp
+++ b/src/STM32LowPower.cpp
@@ -125,11 +125,10 @@ void STM32LowPower::shutdown(uint32_t millis)
   */
 void STM32LowPower::attachInterruptWakeup(uint32_t pin, voidFuncPtrVoid callback, uint32_t mode, LP_Mode LowPowerMode)
 {
-  // All GPIO for idle (smt32 sleep) and sleep (stm32 stop)
   attachInterrupt(pin, callback, mode);
 
   if (LowPowerMode == SHUTDOWN_MODE) {
-    // If Gpio is a Wake up pin activate it for deepSleep (standby stm32) and shutdown
+    // If Gpio is a Wake up pin activate it for shutdown (standby or shutdown stm32)
     LowPower_EnableWakeUpPin(pin, mode);
   }
 }

--- a/src/STM32LowPower.cpp
+++ b/src/STM32LowPower.cpp
@@ -123,13 +123,15 @@ void STM32LowPower::shutdown(uint32_t millis)
   * @param  mode: pin interrupt mode (HIGH, LOW, RISING, FALLING or CHANGE)
   * @retval None
   */
-void STM32LowPower::attachInterruptWakeup(uint32_t pin, voidFuncPtrVoid callback, uint32_t mode)
+void STM32LowPower::attachInterruptWakeup(uint32_t pin, voidFuncPtrVoid callback, uint32_t mode, LP_Mode LowPowerMode)
 {
   // All GPIO for idle (smt32 sleep) and sleep (stm32 stop)
   attachInterrupt(pin, callback, mode);
 
-  // If Gpio is a Wake up pin activate it for deepSleep (standby stm32) and shutdown
-  LowPower_EnableWakeUpPin(pin, mode);
+  if (LowPowerMode == SHUTDOWN_MODE) {
+    // If Gpio is a Wake up pin activate it for deepSleep (standby stm32) and shutdown
+    LowPower_EnableWakeUpPin(pin, mode);
+  }
 }
 
 /**

--- a/src/STM32LowPower.cpp
+++ b/src/STM32LowPower.cpp
@@ -67,7 +67,7 @@ void STM32LowPower::begin(void)
   */
 void STM32LowPower::idle(uint32_t millis)
 {
-  if((millis > 0) || _rtc_wakeup) {
+  if ((millis > 0) || _rtc_wakeup) {
     programRtcWakeUp(millis, IDLE_MODE);
   }
   LowPower_sleep(PWR_MAINREGULATOR_ON);
@@ -81,7 +81,7 @@ void STM32LowPower::idle(uint32_t millis)
   */
 void STM32LowPower::sleep(uint32_t millis)
 {
-  if((millis > 0) || _rtc_wakeup) {
+  if ((millis > 0) || _rtc_wakeup) {
     programRtcWakeUp(millis, SLEEP_MODE);
   }
   LowPower_sleep(PWR_LOWPOWERREGULATOR_ON);
@@ -95,7 +95,7 @@ void STM32LowPower::sleep(uint32_t millis)
   */
 void STM32LowPower::deepSleep(uint32_t millis)
 {
-  if((millis > 0) || _rtc_wakeup) {
+  if ((millis > 0) || _rtc_wakeup) {
     programRtcWakeUp(millis, DEEP_SLEEP_MODE);
   }
   LowPower_stop(_serial);
@@ -109,7 +109,7 @@ void STM32LowPower::deepSleep(uint32_t millis)
   */
 void STM32LowPower::shutdown(uint32_t millis)
 {
-  if((millis > 0) || _rtc_wakeup) {
+  if ((millis > 0) || _rtc_wakeup) {
     programRtcWakeUp(millis, SHUTDOWN_MODE);
   }
   LowPower_shutdown();
@@ -143,7 +143,7 @@ void STM32LowPower::attachInterruptWakeup(uint32_t pin, voidFuncPtrVoid callback
   */
 void STM32LowPower::enableWakeupFrom(HardwareSerial *serial, voidFuncPtrVoid callback)
 {
-  if(serial != NULL) {
+  if (serial != NULL) {
     _serial = &(serial->_serial);
     // Reconfigure serial for low power mode (using HSI as clock source)
     serial->configForLowPower();
@@ -161,7 +161,7 @@ void STM32LowPower::enableWakeupFrom(HardwareSerial *serial, voidFuncPtrVoid cal
   */
 void STM32LowPower::enableWakeupFrom(STM32RTC *rtc, voidFuncPtr callback, void *data)
 {
-  if(rtc == NULL) {
+  if (rtc == NULL) {
     rtc = &(STM32RTC::getInstance());
   }
   _rtc_wakeup = true;
@@ -178,10 +178,10 @@ void STM32LowPower::programRtcWakeUp(uint32_t millis, LP_Mode lp_mode)
 {
   int epoc;
   uint32_t sec;
-  STM32RTC& rtc = STM32RTC::getInstance();
+  STM32RTC &rtc = STM32RTC::getInstance();
   STM32RTC::Source_Clock clkSrc = rtc.getClockSource();
 
-  switch(lp_mode) {
+  switch (lp_mode) {
     case IDLE_MODE:
     case SLEEP_MODE:
       break;
@@ -202,15 +202,15 @@ void STM32LowPower::programRtcWakeUp(uint32_t millis, LP_Mode lp_mode)
   }
   rtc.configForLowPower(clkSrc);
 
-  if(millis > 0) {
+  if (millis > 0) {
     // Convert millisecond to second
     sec = millis / 1000;
     // Minimum is 1 second
-    if (sec == 0){
+    if (sec == 0) {
       sec = 1;
     }
 
     epoc = rtc.getEpoch();
-    rtc.setAlarmEpoch( epoc + sec );
+    rtc.setAlarmEpoch(epoc + sec);
   }
 }

--- a/src/STM32LowPower.h
+++ b/src/STM32LowPower.h
@@ -49,6 +49,13 @@
 #include "STM32RTC.h"
 #include "Wire.h"
 
+enum LP_Mode : uint8_t {
+  IDLE_MODE,
+  SLEEP_MODE,
+  DEEP_SLEEP_MODE,
+  SHUTDOWN_MODE
+};
+
 typedef void (*voidFuncPtrVoid)( void ) ;
 
 class STM32LowPower {
@@ -77,20 +84,12 @@ public:
     shutdown((uint32_t)millis);
   }
 
-  void attachInterruptWakeup(uint32_t pin, voidFuncPtrVoid callback, uint32_t mode);
+  void attachInterruptWakeup(uint32_t pin, voidFuncPtrVoid callback, uint32_t mode, LP_Mode LowPowerMode = SHUTDOWN_MODE);
 
   void enableWakeupFrom(HardwareSerial *serial, voidFuncPtrVoid callback);
   void enableWakeupFrom(STM32RTC *rtc, voidFuncPtr callback, void *data = NULL);
 
 private:
-  enum LP_Mode: uint8_t
-  {
-    IDLE_MODE,
-    SLEEP_MODE,
-    DEEP_SLEEP_MODE,
-    SHUTDOWN_MODE
-  };
-
   bool _configured;     // Low Power mode initialization status
   serial_t *_serial;    // Serial for wakeup from deep sleep
   bool _rtc_wakeup;     // Is RTC wakeup?

--- a/src/STM32LowPower.h
+++ b/src/STM32LowPower.h
@@ -56,44 +56,48 @@ enum LP_Mode : uint8_t {
   SHUTDOWN_MODE
 };
 
-typedef void (*voidFuncPtrVoid)( void ) ;
+typedef void (*voidFuncPtrVoid)(void) ;
 
 class STM32LowPower {
-public:
-  STM32LowPower();
+  public:
+    STM32LowPower();
 
-  void begin(void);
+    void begin(void);
 
-  void idle(uint32_t millis = 0);
-  void idle(int millis) {
-    idle((uint32_t)millis);
-  }
+    void idle(uint32_t millis = 0);
+    void idle(int millis)
+    {
+      idle((uint32_t)millis);
+    }
 
-  void sleep(uint32_t millis = 0);
-  void sleep(int millis) {
-    sleep((uint32_t)millis);
-  }
+    void sleep(uint32_t millis = 0);
+    void sleep(int millis)
+    {
+      sleep((uint32_t)millis);
+    }
 
-  void deepSleep(uint32_t millis = 0);
-  void deepSleep(int millis) {
-    deepSleep((uint32_t)millis);
-  }
+    void deepSleep(uint32_t millis = 0);
+    void deepSleep(int millis)
+    {
+      deepSleep((uint32_t)millis);
+    }
 
-  void shutdown(uint32_t millis = 0);
-  void shutdown(int millis) {
-    shutdown((uint32_t)millis);
-  }
+    void shutdown(uint32_t millis = 0);
+    void shutdown(int millis)
+    {
+      shutdown((uint32_t)millis);
+    }
 
-  void attachInterruptWakeup(uint32_t pin, voidFuncPtrVoid callback, uint32_t mode, LP_Mode LowPowerMode = SHUTDOWN_MODE);
+    void attachInterruptWakeup(uint32_t pin, voidFuncPtrVoid callback, uint32_t mode, LP_Mode LowPowerMode = SHUTDOWN_MODE);
 
-  void enableWakeupFrom(HardwareSerial *serial, voidFuncPtrVoid callback);
-  void enableWakeupFrom(STM32RTC *rtc, voidFuncPtr callback, void *data = NULL);
+    void enableWakeupFrom(HardwareSerial *serial, voidFuncPtrVoid callback);
+    void enableWakeupFrom(STM32RTC *rtc, voidFuncPtr callback, void *data = NULL);
 
-private:
-  bool _configured;     // Low Power mode initialization status
-  serial_t *_serial;    // Serial for wakeup from deep sleep
-  bool _rtc_wakeup;     // Is RTC wakeup?
-  void programRtcWakeUp(uint32_t millis, LP_Mode lp_mode);
+  private:
+    bool _configured;     // Low Power mode initialization status
+    serial_t *_serial;    // Serial for wakeup from deep sleep
+    bool _rtc_wakeup;     // Is RTC wakeup?
+    void programRtcWakeUp(uint32_t millis, LP_Mode lp_mode);
 };
 
 extern STM32LowPower LowPower;


### PR DESCRIPTION
attachInterruptWakeup() add parameter to define LowPowerMode
    
Up to now, when configuring pin for wakeup, if pin has system wakeup capability (able to wakeup from Shutdown), this capabilty is enable (even if we only want to go in idle, sleep or depsleep).
It has the inconvenient to enable automaticvally pull down on the pin, on some STM32 families like L0.

Aim of this patch is to be able to configure pins to wakeup from idle, sleep or deepsleep, but without activating System wakeup capability.
It means it will not be able to wake from Shutdown.
And thus there is no pull down activated.
    
For backward compatibility, default LowPowerMode is SHUTDOWN_MODE
    
Fixes #19