### PR TITLE
Allow sleepings fractions of a second

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,23 +3,23 @@ Arduino library to support STM32 Low Power.
 
 ## Requirement
  * [Arduino_Core_STM32](https://github.com/stm32duino/Arduino_Core_STM32) version >= 1.3.0
- * [STM32RTC](https://github.com/stm32duino/STM32RTC)
+ * [STM32RTC](https://github.com/stm32duino/STM32RTC) version >= 1.0.4
 
 ## API
 
 * **`void begin()`**: configure the Low Power
 
 * **`void idle(uint32_t millis)`**: enter in idle mode  
-**param** millis (optional): number of milliseconds before to exit the mode. At least 1000 ms. The RTC is used in alarm mode to wakeup the chip in millis milliseconds.
+**param** millis (optional): number of milliseconds before to exit the mode. The RTC is used in alarm mode to wakeup the chip in millis milliseconds.
 
 * **`void sleep(uint32_t millis)`**: enter in sleep mode  
-**param** millis (optional): number of milliseconds before to exit the mode. At least 1000 ms. The RTC is used in alarm mode to wakeup the chip in millis milliseconds.
+**param** millis (optional): number of milliseconds before to exit the mode. he RTC is used in alarm mode to wakeup the chip in millis milliseconds.
 
 * **`void deepSleep(uint32_t millis)`**: enter in deepSleep mode  
-**param** millis (optional): number of milliseconds before to exit the mode. At least 1000 ms. The RTC is used in alarm mode to wakeup the chip in millis milliseconds.
+**param** millis (optional): number of milliseconds before to exit the mode. The RTC is used in alarm mode to wakeup the chip in millis milliseconds.
 
 * **`void shutdown(uint32_t millis)`**: enter in shutdown mode
-**param** millis (optional): number of milliseconds before to exit the mode. At least 1000 ms. The RTC is used in alarm mode to wakeup the board in millis milliseconds.
+**param** millis (optional): number of milliseconds before to exit the mode. The RTC is used in alarm mode to wakeup the board in millis milliseconds.
 
 * **`void attachInterruptWakeup(uint32_t pin, voidFuncPtrVoid callback, uint32_t mode)`**: Enable GPIO pin in interrupt mode. If the pin is a wakeup pin, it is configured as wakeup source (see board documentation).  
 **param** pin: pin number  

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=STM32duino Low Power
-version=1.0.3
+version=1.0.4
 author=Wi6Labs
 maintainer=stm32duino
 sentence=Power save primitives features for STM32 boards

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=STM32duino Low Power
-version=1.0.4
+version=1.0.3
 author=Wi6Labs
 maintainer=stm32duino
 sentence=Power save primitives features for STM32 boards

--- a/src/STM32LowPower.cpp
+++ b/src/STM32LowPower.cpp
@@ -169,13 +169,14 @@ void STM32LowPower::enableWakeupFrom(STM32RTC *rtc, voidFuncPtr callback, void *
 
 /**
   * @brief  Configure the RTC alarm
-  * @param  millis: time of the alarm in milliseconds. At least 1000ms.
+  * @param  millis: time of the alarm in milliseconds.
   * @param  lp_mode: low power mode targeted.
   * @retval None
   */
 void STM32LowPower::programRtcWakeUp(uint32_t millis, LP_Mode lp_mode)
 {
   int epoc;
+  uint32_t epoc_ms;
   uint32_t sec;
   STM32RTC &rtc = STM32RTC::getInstance();
   STM32RTC::Source_Clock clkSrc = rtc.getClockSource();
@@ -204,12 +205,17 @@ void STM32LowPower::programRtcWakeUp(uint32_t millis, LP_Mode lp_mode)
   if (millis > 0) {
     // Convert millisecond to second
     sec = millis / 1000;
-    // Minimum is 1 second
-    if (sec == 0) {
-      sec = 1;
+    millis = millis % 1000;
+
+    epoc = rtc.getEpoch(&epoc_ms);
+    
+    //Update epoch_ms - might need to add a second to epoch
+    epoc_ms += millis;
+    if (epoc_ms >= 1000) {
+      sec ++;
+      epoc_ms -= 1000;
     }
 
-    epoc = rtc.getEpoch();
-    rtc.setAlarmEpoch(epoc + sec);
+    rtc.setAlarmEpoch(epoc + sec, STM32RTC::MATCH_DHHMMSS, epoc_ms);
   }
 }


### PR DESCRIPTION
Built on PR https://github.com/stm32duino/STM32RTC/pull/25 - cannot be merged before this dependency is merged.

This allows sleeping fractions of a second. I noticed that previously the limit was not only that delay had to be more than 1 seconds but also that the sleep was being rounded to the lowest second. This lead in my sketch to an accumulated error of being "ahead" by several seconds after just one hour.

With this patch and using an external 32 KHz quarz I am able to sleep with not even a second error in the same 1 hour test.