### PR TITLE
Restore PWR clock at wakeup

### DIFF
--- a/src/low_power.c
+++ b/src/low_power.c
@@ -347,6 +347,11 @@ void LowPower_EnableWakeUpUart(serial_t *serial, void (*FuncPtr)(void))
   */
 WEAK void SystemClock_ConfigFromStop(void)
 {
+#if defined(__HAL_RCC_PWR_CLK_ENABLE)
+  /* Enable PWR clock, needed for example: voltage scaling */
+  __HAL_RCC_PWR_CLK_ENABLE();
+#endif
+
   SystemClock_Config();
 }
 


### PR DESCRIPTION
Restore PWR clock at wakeup

This avoid to miss it in system clock configuration,
as it is not systematically done by cubeMX

This is complementary to Arduino_Core_STM32 PR:
https://github.com/stm32duino/Arduino_Core_STM32/pull/1311