### PR TITLE
stm32L4+ going to STOP2 lowpower mode must keep SRAM3

### DIFF
--- a/src/low_power.c
+++ b/src/low_power.c
@@ -295,6 +295,10 @@ void LowPower_stop(serial_t *obj)
       || (WakeUpUart->Instance == (USART_TypeDef *)LPUART2_BASE)
 #endif
      ) {
+#if defined(PWR_CR1_RRSTP)
+    // STM32L4+ must keep SRAM3 content when entering STOP2 lowpower mode
+    HAL_PWREx_EnableSRAM3ContentRetention();
+#endif /* PWR_CR1_RRSTP */
     // STM32L4xx supports STOP2 mode which halves consumption
     HAL_PWREx_EnterSTOP2Mode(PWR_STOPENTRY_WFI);
   } else


### PR DESCRIPTION
On the stm32L4+ , the low power DEEP_SLEEP mode corresponds to STOP2 low power
mode. In this case, the SRAM3 must be powered during the low power phase since it is a part of the SRAM area for this target (SRAM is made of SRAM1+SRAM2+SRAM3).
By default, the content of the SRAM3 is lost during STOP2 low power mode and consequently this must be changed. 

Fixes #64

Signed-off-by: Francois Ramu <francois.ramu@st.com>