### PR TITLE
fix: ExternalWakeup: assign a PinNumber to USER_BTN

### DIFF
--- a/examples/ExternalWakeup/ExternalWakeup.ino
+++ b/examples/ExternalWakeup/ExternalWakeup.ino
@@ -20,7 +20,7 @@ volatile int repetitions = 1;
 
 // Pin used to trigger a wakeup
 #ifndef USER_BTN
-#define USER_BTN SYS_WKUP1
+#define USER_BTN pinNametoDigitalPin(SYS_WKUP1)
 #endif
 
 const int pin = USER_BTN;


### PR DESCRIPTION
fix: ExternalWakeup: assign a PinNumber to USER_BTN

SYS_WKUP1 is a PinName whereas USER_BTN expect a PinNumber.
