### PR TITLE
Fix conditional compilation for Stop mode for U5

### DIFF
--- a/src/low_power.c
+++ b/src/low_power.c
@@ -815,7 +815,7 @@ void LowPower_stop(serial_t *obj)
 #endif
   /* Enter Stop mode */
 #if defined(UART_WKUP_SUPPORT) && (defined(PWR_CPUCR_RETDS_CD) || \
-    defined(LL_PWR_MODE_STOP2))
+    defined(LL_PWR_MODE_STOP2) || defined(LL_PWR_STOP2_MODE))
   if ((WakeUpUart == NULL)
       || (WakeUpUart->Instance == (USART_TypeDef *)LPUART1_BASE)
 #ifdef LPUART2_BASE


### PR DESCRIPTION
The U5 HAL uses the similarly named `LL_PWR_STOP2_MODE`, as opposed to the standard `LL_PWR_MODE_STOP2`.

Validated on the Blues Heron (STM32U575OIY6QTR).